### PR TITLE
Use select() + non-blocking recv() instead of blocking recv()

### DIFF
--- a/oshw/linux/nicdrv.c
+++ b/oshw/linux/nicdrv.c
@@ -165,11 +165,13 @@ int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
    }   
    /* we use RAW packet socket, with packet type ETH_P_ECAT */
    *psock = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ECAT));
-   
-   timeout.tv_sec =  0;
-   timeout.tv_usec = 1; 
-   r = setsockopt(*psock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
-   r = setsockopt(*psock, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+
+   /* timeout.tv_sec =  0; */
+   /* timeout.tv_usec = 1; */
+   /* r = setsockopt(*psock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)); */
+   /* r = setsockopt(*psock, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)); */
+   int flags = 0;
+   fcntl(*psock, F_SETFL, flags | O_NONBLOCK);
    i = 1;
    r = setsockopt(*psock, SOL_SOCKET, SO_DONTROUTE, &i, sizeof(i));
    /* connect socket to NIC by name */
@@ -362,7 +364,24 @@ static int ecx_recvpkt(ecx_portt *port, int stacknumber)
       stack = &(port->redport->stack);
    }
    lp = sizeof(port->tempinbuf);
-   bytesrx = recv(*stack->sock, (*stack->tempbuf), lp, 0);
+   FD_ZERO(&readfds);
+   FD_SET(*stack->sock, &readfds);
+   tv.tv_sec = 0;
+   tv.tv_usec = 1;
+   rv = select(*stack->sock+1, &readfds, NULL, NULL, &tv);
+   if( rv < 0 )
+   {
+      printf ("NG!!!\n");
+   }
+   else if ( rv == 0 )
+   {
+      /* Polling... */
+   }
+   else
+   {
+      bytesrx = recv(*stack->sock, (*stack->tempbuf), lp, MSG_DONTWAIT );
+   }
+
    port->tempinbufs = bytesrx;
    
    return (bytesrx > 0);


### PR DESCRIPTION
* Using select() + non-blocking recv() performs better realtime
  perofmance than using blocking recv().
* Closes GITAI/gitai_ethercat_controller#111