### PR TITLE
Increase max error name to avoid format error

### DIFF
--- a/SOEM/soem/ethercatprint.c
+++ b/SOEM/soem/ethercatprint.c
@@ -17,7 +17,7 @@
 #include "ethercattype.h"
 #include "ethercatmain.h"
 
-#define EC_MAXERRORNAME 127
+#define EC_MAXERRORNAME 255
 
 /** SDO error list type definition */
 typedef struct


### PR DESCRIPTION
* Error string can be longer than 127 like
`Time:   93757.005 SDO slave:8 index:6001.01 error:08000022 Data cannot be transferred or stored to the application because of the present device state`
* In order to avoid error in sprintf, increase the maximum length of
  the error string.